### PR TITLE
Fix Smart Circulation app, `atomicState.minutes` -> `circMinutes`

### DIFF
--- a/smartapps/sandood/ecobee-suite-smart-circulation.src/ecobee-suite-smart-circulation.groovy
+++ b/smartapps/sandood/ecobee-suite-smart-circulation.src/ecobee-suite-smart-circulation.groovy
@@ -805,7 +805,7 @@ void updateMyLabel() {
 	if (settings.tempDisable) {
 		newLabel = myLabel + '<span style="color:red"> (paused)</span>'
 		if (app.label != newLabel) app.updateLabel(newLabel)
-	} else if (atomicState.minutes == 'quiet time') {
+	} else if (atomicState.circMinutes == 'quiet time') {
 		newLabel = myLabel + '<span style="color:green"> (quiet time)</span>'
 		if (app.label != newLabel) app.updateLabel(newLabel)
 	} else if (minutes > -1) { 


### PR DESCRIPTION
[An edit](https://github.com/SANdood/Ecobee-Suite/commit/da14c6d97fded23755e4ce804864502c7c8287c5) made for 1.8.00a (2020) seems to have mistakenly used `atomicState.minutes` instead of `atomicState.circMinutes`, causing a ClassCastException during evaluation if this conditional logic is executed.